### PR TITLE
Fixed Research WorkGiverDef's

### DIFF
--- a/Defs/WorkGivers.xml
+++ b/Defs/WorkGivers.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Defs>
 
+  <!--
   <WorkGiverDef>
     <defName>ResearchTech</defName>
     <label>Research technologies</label>
@@ -14,6 +15,7 @@
       <li>HiTechResearchBench</li>
     </fixedBillGiverDefs>
   </WorkGiverDef>
+  -->
 
   <WorkGiverDef>
     <defName>DocumentTech</defName>

--- a/Defs/WorkGivers.xml
+++ b/Defs/WorkGivers.xml
@@ -8,6 +8,7 @@
     <workType>Research</workType>
     <verb>research</verb>
     <gerund>researching at</gerund>
+    <priorityInType>100</priorityInType>
     <fixedBillGiverDefs>
       <li>SimpleResearchBench</li>
       <li>HiTechResearchBench</li>
@@ -21,6 +22,7 @@
     <workType>Research</workType>
     <verb>write</verb>
     <gerund>writing at</gerund>
+    <priorityInType>101</priorityInType>
     <fixedBillGiverDefs>
       <li>StudyDesk</li>
     </fixedBillGiverDefs>

--- a/Defs/WorkGivers.xml
+++ b/Defs/WorkGivers.xml
@@ -22,7 +22,7 @@
     <workType>Research</workType>
     <verb>write</verb>
     <gerund>writing at</gerund>
-    <priorityInType>101</priorityInType>
+    <priorityInType>110</priorityInType>
     <fixedBillGiverDefs>
       <li>StudyDesk</li>
     </fixedBillGiverDefs>

--- a/Patches/Patches.xml
+++ b/Patches/Patches.xml
@@ -1,9 +1,26 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
 
-  <!--remove vanilla Research WorkGiverDef-->
-  <Operation Class="PatchOperationRemove">
-    <xpath>/Defs/WorkGiverDef[defName = "Research"]</xpath>
+  <!--to Research WorkGiverDef-->
+  <Operation Class="PatchOperationSequence">
+    <success>Always</success>
+    <operations>
+       <li Class="PatchOperationReplace">
+        <xpath>/Defs/WorkGiverDef[defName = "Research"]/giverClass</xpath>
+        <value>
+          <giverClass>HumanResources.WorkGiver_ResearchTech</giverClass>
+        </value>
+      </li>
+      <li Class="PatchOperationAdd">
+        <xpath>/Defs/WorkGiverDef[defName = "Research"]</xpath>
+	    <value>
+          <fixedBillGiverDefs>
+            <li>SimpleResearchBench</li>
+            <li>HiTechResearchBench</li>
+          </fixedBillGiverDefs>
+        </value>
+      </li>
+	</operations>
   </Operation>
 
   <!--to Stats_Building_Special-->
@@ -18,7 +35,7 @@
   <Operation Class="PatchOperationSequence">
     <success>Always</success>
     <operations>
-       <li Class="PatchOperationReplace">
+      <li Class="PatchOperationReplace">
         <xpath>/Defs/ThingDef[defName = "SimpleResearchBench" or defName = "HiTechResearchBench"]/thingClass</xpath>
         <value>
           <thingClass>Building_WorkTable</thingClass>

--- a/Patches/Patches.xml
+++ b/Patches/Patches.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
 
+  <!--remove vanilla Research WorkGiverDef-->
+  <Operation Class="PatchOperationRemove">
+    <xpath>/Defs/WorkGiverDef[defName = "Research"]</xpath>
+  </Operation>
+
   <!--to Stats_Building_Special-->
   <Operation Class="PatchOperationAdd">
     <xpath>*/StatDef[defName = "ResearchSpeedFactor"]/parts</xpath>


### PR DESCRIPTION
* Removed the Vanilla Research WorkGiverDef
* The new ResearchTech WorkGiverDef now has the same Priority as the old Research WorkGiverDef, to put it above the Scanning WorkGiverDef's
* The DocumentTech WorkGiverDef has a higher Priority than ResearchTech, so Researchers document Tech before they start new research.