### PR TITLE
Made the Tech tab use english Titles.

### DIFF
--- a/Languages/English/Keyed/HumanResources_keys.xml
+++ b/Languages/English/Keyed/HumanResources_keys.xml
@@ -3,8 +3,8 @@
   
   <!--UI-->
   <TabKnowledge>Tech</TabKnowledge>
-  <TabKnowledgeTitle>Conhecimentos</TabKnowledgeTitle>
-  <TabKnowledgeWeapons>Perícia com armas</TabKnowledgeWeapons>
+  <TabKnowledgeTitle>Knowledge</TabKnowledgeTitle>
+  <TabKnowledgeWeapons>Weapons Proficiency</TabKnowledgeWeapons>
   <TabCatalogue>Catalog</TabCatalogue>
   <ShowCommon>show common</ShowCommon>
   <AvailableBooksReport>{0} books in {1} shelves</AvailableBooksReport>


### PR DESCRIPTION
When the Commit 22485bf25d49ca291fccaea836553fd08590179d made the Tech Tab translatable, it also provided a non-English translation.
This changes the Translation back to its original Content.