### PR TITLE
Royalty Persona Weapons can now be learned.

### DIFF
--- a/Defs/Recipes.xml
+++ b/Defs/Recipes.xml
@@ -142,6 +142,7 @@
         <filter>
           <categories>
             <li>WeaponsMelee</li>
+            <li>WeaponsMeleeBladelink</li>
           </categories>
         </filter>
         <count>1</count>
@@ -150,6 +151,7 @@
     <fixedIngredientFilter>
       <categories>
         <li>WeaponsMelee</li>
+        <li>WeaponsMeleeBladelink</li>
       </categories>
     </fixedIngredientFilter>
   </RecipeDef>


### PR DESCRIPTION
Adding the Persona Weapons to the Recipe, caused Ranged Weapons to be also shown as potential ingredients, but this is only a "visual" Bug. They still cannot be trained at the Training Dunny.
![20200618144249_1](https://user-images.githubusercontent.com/66798382/85022020-f8fdeb80-b172-11ea-82ef-22d352e35180.jpg)
