### PR TITLE
Also added the Scenario Rule to VFE - Settlers and Pawnmorpher

### DIFF
--- a/Patches/Patches_Pawnmorpher.xml
+++ b/Patches/Patches_Pawnmorpher.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<!--tachyonite.pawnmorpherpublic-->
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Pawnmorpher</li>
+		</mods>
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/ScenarioDef[defName = "Escaped Morphs"]/scenario/parts</xpath>
+			<value>
+				<li Class="ScenPart_Rule_DisallowDesignator">
+					<def>Rule_knowAllStartingWeapons</def>
+				</li>
+			</value>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Patches_VFE-Settlers.xml
+++ b/Patches/Patches_VFE-Settlers.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<!--OskarPotocki.VanillaFactionsExpanded.SettlersModule-->
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Factions Expanded - Settlers</li>
+		</mods>
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/ScenarioDef[defName = "VFES_Bandits"]/scenario/parts</xpath>
+			<value>
+				<li Class="ScenPart_Rule_DisallowDesignator">
+					<def>Rule_knowAllStartingWeapons</def>
+				</li>
+			</value>
+		</match>
+	</Operation>
+</Patch>

--- a/Source/Knowledge/CompKnowledge.cs
+++ b/Source/Knowledge/CompKnowledge.cs
@@ -259,7 +259,7 @@ namespace HumanResources
                         }
                         if (Prefs.LogVerbose) stringBuilder.Append(pawn.gender.GetPossessive().ToLower() + " faction's tech level");
                     }
-                    if (isPlayer && ModBaseHumanResources.WeaponPoolIncludesScenario && !ModBaseHumanResources.FreeScenarioWeapons)
+                    if (isPlayer && ModBaseHumanResources.WeaponPoolIncludesScenario && !(ModBaseHumanResources.FreeScenarioWeapons || ModBaseHumanResources.unlocked.knowAllStartingWeapons))
                     {
                         proficientWeapons.AddRange(ModBaseHumanResources.unlocked.startingWeapons.Where(x => TestIfWeapon(x, isFighter)));
                         string connector = ModBaseHumanResources.WeaponPoolIncludesTechLevel ? " and " : "";


### PR DESCRIPTION
Adjusted if check that was forgotten in 6677c37823beee3fba3c31f924cefb1e57df5249

Why these two Mods:
* Settlers
  * Only Ranged Weapons
  * they are supposed to Bandits that fled after their last gig.
* Pawnmorper:
  * All Weapons would need to be researched, one even requiring an multianalyzer
  * Escapes from Genetic Lab, should know the weapons they used to escape

Other Mods i looked at:
* VFE - Medieval
  * You start with 6 Pawns and 3 Weapons. 2 Weapons may need to be learned, but you start with that research.
  * One Lord and his retainers. Not every Pawn should need to know every Weapon available.
* Dragons Descent:
  * Variant of Vanilla Tribal start.

P.S. Pawnmoprher works with this mod, even though it uses HAF. 
* Partialy morped pawns work without issue.
* Pawns that turned into an Animal lose no knowledge if reverted back to a human.
