### PR TITLE
Improve support for Reverse Commands by avoiding dynamic right-click translations

### DIFF
--- a/Languages/English/Keyed/HumanResources_keys.xml
+++ b/Languages/English/Keyed/HumanResources_keys.xml
@@ -66,7 +66,7 @@
   <DoesntKnowHowToCraft>{0_nameDef} doesn't know how to {1} (requires {2}).</DoesntKnowHowToCraft>
   <DoesntKnowThisPlant>{0_nameDef} doesn't know how to cultivate {1} (requires {2}).</DoesntKnowThisPlant>
   <UnknownWeapon>pawn has not been trained to use this weapon</UnknownWeapon>
-  <EvilWeapon>pawn believes finds this strange weapon incomprehensible</EvilWeapon>
+  <EvilWeapon>pawn finds this strange weapon incomprehensible</EvilWeapon>
   <TechAlreadyKnown>{0} is already known.</TechAlreadyKnown>
   
   <!--Go Explore-->

--- a/Languages/English/Keyed/HumanResources_keys.xml
+++ b/Languages/English/Keyed/HumanResources_keys.xml
@@ -65,8 +65,8 @@
   <DoesntKnowHowToRepair>{0_nameDef} doesn't know how to repair a {1} (requires {2}).</DoesntKnowHowToRepair>
   <DoesntKnowHowToCraft>{0_nameDef} doesn't know how to {1} (requires {2}).</DoesntKnowHowToCraft>
   <DoesntKnowThisPlant>{0_nameDef} doesn't know how to cultivate {1} (requires {2}).</DoesntKnowThisPlant>
-  <UnknownWeapon>{0_nameDef} has not been trained to use this weapon.</UnknownWeapon>
-  <EvilWeapon>{0_nameDef} believes this strange weapon is evil, {0_pronoun} won't touch it.</EvilWeapon>
+  <UnknownWeapon>pawn has not been trained to use this weapon</UnknownWeapon>
+  <EvilWeapon>pawn believes finds this strange weapon incomprehensible</EvilWeapon>
   <TechAlreadyKnown>{0} is already known.</TechAlreadyKnown>
   
   <!--Go Explore-->

--- a/Source/Harmony/Compatibility/SimpleSidearms_Patches.cs
+++ b/Source/Harmony/Compatibility/SimpleSidearms_Patches.cs
@@ -26,7 +26,7 @@ namespace HumanResources
 
         public static bool canCarrySidearmÌnstance_Prefix(ThingWithComps sidearmThing, Pawn pawn, out string errString)
         {
-            errString = ModBaseHumanResources.unlocked.weapons.Contains(sidearmThing.def) ? "UnknownWeapon".Translate(pawn) : "EvilWeapon".Translate(pawn);
+            errString = ModBaseHumanResources.unlocked.weapons.Contains(sidearmThing.def) ? "UnknownWeapon".Translate() : "EvilWeapon".Translate();
             if (pawn.RaceProps.Humanlike && pawn.Faction != null && pawn.Faction.IsPlayer && pawn.TryGetComp<CompKnowledge>() != null) return HarmonyPatches.CheckKnownWeapons(pawn, sidearmThing);
             else return true;
         }

--- a/Source/Harmony/EquipmentUtility_CanEquip.cs
+++ b/Source/Harmony/EquipmentUtility_CanEquip.cs
@@ -15,7 +15,7 @@ namespace HumanResources
             if (thing.TryGetComp<CompEquippable>() != null) equipment = thing as ThingWithComps;
             if (pawn.Faction != null && pawn.Faction.IsPlayer && pawn.RaceProps.Humanlike && equipment != null && equipment.def.IsWeapon && !HarmonyPatches.CheckKnownWeapons(pawn, equipment))
             {
-                cantReason = ModBaseHumanResources.unlocked.weapons.Contains(equipment.def) ? "UnknownWeapon".Translate(pawn) : "EvilWeapon".Translate(pawn);
+                cantReason = ModBaseHumanResources.unlocked.weapons.Contains(equipment.def) ? "UnknownWeapon".Translate() : "EvilWeapon".Translate();
                 return false;
             }
             cantReason = null;


### PR DESCRIPTION
So, presumably you're aware of this rather popular mod: [Reverse Commands](https://steamcommunity.com/sharedfiles/filedetails/?id=858744731&searchtext=reverse).

Unfortunately, at the moment, Human Resources doesn't play very well with it. First off, here's what right-clicking on a random object with Reverse Commands *normally* looks like:

<img width="496" alt="Screen Shot 2020-09-07 at 17 36 39" src="https://user-images.githubusercontent.com/200/92419051-b673fb80-f130-11ea-9fe3-a52b0f5309ef.png">

Notably, "pawn hates and/or is not assigned to cleaning" only shows up *once*, despite there being several pawns to whom that applies; but only the pawn named 'Mister' has the reason "pawn hates and/or is not assigned to hauling."

Now, let's look at the right-click menus generated for Human Resources:

<img width="487" alt="Screen Shot 2020-09-07 at 17 39 02" src="https://user-images.githubusercontent.com/200/92419110-12d71b00-f131-11ea-904a-2630f2b01dc5.png">

<img width="904" alt="Screen Shot 2020-09-07 at 17 38 28" src="https://user-images.githubusercontent.com/200/92419089-f76c1000-f130-11ea-98c0-f29235e2ddab.png">

I'd posit that this mod is popular enough - and the UX benefit of redundantly naming the selected pawn in the right-click menu (which the base-game never does) is low enough - that this behaviour should be removed.

I'm no C# expert; but hopefully my attached suggestions are fairly clear: use static strings, instead of dynamic ones, wherever a right-click menu is generated. I only changed one example in this commit, but I'll guess that you get the idea!