### PR TITLE
Add work-around to avoid consuming ammo every tick

### DIFF
--- a/Source/Harmony/HarmonyPatches.cs
+++ b/Source/Harmony/HarmonyPatches.cs
@@ -16,7 +16,8 @@ namespace HumanResources
             ResearchPal = false,
             PrisonLabor = false,
             RunSpecialCases = false,
-            VisibleBooksCategory = false;
+            VisibleBooksCategory = false,
+            ConserveAmmo = false;
 
         public static Harmony Instance
         {
@@ -99,6 +100,16 @@ namespace HumanResources
             x.PackageIdPlayerFacing == "fluffy.fluffybreakdowns"))
             {
                 RunSpecialCases = true;
+            }
+
+            //Work-arounds for Combat Extended and similar bullet mods
+            if (LoadedModManager.RunningModsListForReading.Any(x =>
+            x.PackageIdPlayerFacing == "CETeam.CombatExtended" ||
+            x.PackageIdPlayerFacing == "syrchalis.bulletcasings" ||
+            x.PackageIdPlayerFacing == "LimeTreeSnake.Community.Ammunition"))
+            {
+                Log.Message("[HumanResources] Ammunition mod detected!");
+                ConserveAmmo = true;
             }
         }
 

--- a/Source/Work/JobDriver_LearnWeapon.cs
+++ b/Source/Work/JobDriver_LearnWeapon.cs
@@ -300,7 +300,8 @@ namespace HumanResources
                 //pawn posture
                 Verb verbToUse = actor.TryGetAttackVerb(currentWeapon, true);
                 LocalTargetInfo target = actor.jobs.curJob.GetTarget(TargetIndex.A);
-                pawn.stances.SetStance(new Stance_Warmup(1, target, verbToUse));
+                if (!HarmonyPatches.ConserveAmmo)
+                    pawn.stances.SetStance(new Stance_Warmup(1, target, verbToUse));
 
                 //sound:
                 if (!unknown && verbToUse.verbProps != null && verbToUse.verbProps.warmupTime > 0)

--- a/Source/Work/JobDriver_PlayWithWeapon.cs
+++ b/Source/Work/JobDriver_PlayWithWeapon.cs
@@ -22,7 +22,8 @@ namespace HumanResources
 
             //pawn posture
             LocalTargetInfo target = pawn.jobs.curJob.GetTarget(TargetIndex.A);
-            pawn.stances.SetStance(new Stance_Warmup(1, target, verbToUse));
+            if (!HarmonyPatches.ConserveAmmo)
+                pawn.stances.SetStance(new Stance_Warmup(1, target, verbToUse));
 
             //sound:
             if (verbToUse.verbProps != null && verbToUse.verbProps.warmupTime > 0)


### PR DESCRIPTION
Seems this is the line which causes it. Disabling that when ammo-type mods are detected works around the problem, at the cost of just having the colonist stand there and stare at the target while the gunfire sounds play.

I tried a couple of more elegant things, including how Misc. Training does it, but none of them really worked properly... was always either firing too much, bullets and sounds at completely the wrong times, or other weirdness.

Anyhow, until you can find a better solution, this will do the job and solves #92