### PR TITLE
Stop zeroing libraryFreeSapce on every map gen

### DIFF
--- a/Source/Base/ModBaseHumanResources.cs
+++ b/Source/Base/ModBaseHumanResources.cs
@@ -177,8 +177,8 @@ namespace HumanResources
             {
                 unlocked.RegisterStartingResources();
                 unlocked.RecacheUnlockedWeapons();
+                unlocked.libraryFreeSpace = 0;
             }
-            unlocked.libraryFreeSpace = 0;
         }
 
         //Dealing with older versions


### PR DESCRIPTION
Presumably we only want to zero libraryFreeSpace on initial map generation, not on any subsequent map generation.