### PR TITLE
DNM: Implement active caching for weapons and growables

### DIFF
--- a/Languages/English/Keyed/HumanResources_keys.xml
+++ b/Languages/English/Keyed/HumanResources_keys.xml
@@ -63,7 +63,11 @@
   <ResearchSpeedTiedToDifficultyDesc>If checked, the base speed for research is tied to the difficulty settings, with no changes on Easy and up to 30% slower on Hard. If unchecked, it defaults to 10% slower than vanilla.</ResearchSpeedTiedToDifficultyDesc>
   <StudySpeedTiedToDifficultyTitle>Difficulty settings slows down tech studying.</StudySpeedTiedToDifficultyTitle>
   <StudySpeedTiedToDifficultyDesc>If checked, the base speed for studying new techs is tied to the difficulty settings, dropping 10% on Medium up to 20% on Hard.</StudySpeedTiedToDifficultyDesc>
-
+  <!--NEW--><OptimizationExperimentalGrowingCacheTitle>Experimental: Expand known growable cache into memory</OptimizationExperimentalGrowingCacheTitle>
+  <!--NEW--><OptimizationExperimentalGrowingCacheDesc>Requires restart if switched on! This experimental setting will enable expansion of growable cache into memory and will update cache only when pawn is spawned or learned something new instead of reevaluating known list each job search.</OptimizationExperimentalGrowingCacheDesc>
+  <!--NEW--><OptimizationExperimentalWeaponCacheTitle>Experimental: Expand known weapons caches into memory</OptimizationExperimentalWeaponCacheTitle>
+  <!--NEW--><OptimizationExperimentalWeaponCacheDesc>Requires restart if switched on! This experimental settings will enable expansion of global and per-pawn known weapon caches into memory instead of recalculating them each request.</OptimizationExperimentalWeaponCacheDesc>
+  
   <!--Things-->
   <BookStoreEmpty>Empty</BookStoreEmpty>
   <BookStoreCapacity>Archived technologies: {0}/{1}</BookStoreCapacity>

--- a/Languages/Russian/Keyed/HumanResources_keys.xml
+++ b/Languages/Russian/Keyed/HumanResources_keys.xml
@@ -63,7 +63,11 @@
 	<ResearchSpeedTiedToDifficultyDesc>Если включено, то скорость исследования становится зависимой от настроек сложности игры.\nБез изменений на низком уровне сложности и вплоть до -30% на высоком.\nЕсли выключено, скорость исследования фиксируется на отметке 90% от базового значения игры.</ResearchSpeedTiedToDifficultyDesc>
 	<StudySpeedTiedToDifficultyTitle>Сложность => скорость изучения</StudySpeedTiedToDifficultyTitle>
 	<StudySpeedTiedToDifficultyDesc>Если включено, то скорость изучения новых технологий становится зависимой от настроек сложности.\nНа среднем уровне сложности: -10%\nНа высоком уровне сложности: -20%</StudySpeedTiedToDifficultyDesc>
-
+	<OptimizationExperimentalGrowingCacheTitle>Экспериментально: Расширяет известные растения в память</OptimizationExperimentalGrowingCacheTitle>
+	<OptimizationExperimentalGrowingCacheDesc>Требует перезапуск, если переведено во включенное состояние! Данная экспериментальная опция включает кэш для известных растений и обновляет его только при порождении пешки или получении нового знания, вместо синтеза каждый поиск работы.</OptimizationExperimentalGrowingCacheDesc>
+	<OptimizationExperimentalWeaponCacheTitle>Экспериментально: Расширяет известное оружие в память</OptimizationExperimentalWeaponCacheTitle>
+	<OptimizationExperimentalWeaponCacheDesc>Требует перезапуск, если переведено во включенное состояние! Данная экспериментальная опция включает кэш для известного вооружения и обновляет его только в случае изменения конфигурации доступного к изучению оружия.</OptimizationExperimentalWeaponCacheDesc>
+	
 	<!--Things-->
 	<BookStoreEmpty>Пусто</BookStoreEmpty>
 	<BookStoreCapacity>Технологий в архиве: {0}/{1}</BookStoreCapacity>

--- a/Source/Base/IImmutableSpecialRegistryCache.cs
+++ b/Source/Base/IImmutableSpecialRegistryCache.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using Verse;
+
+namespace HumanResources
+{
+    public interface IImmutableSpecialRegistryCache
+    {
+        IEnumerable<ThingDef> AllWeapons { get; }
+        
+    }
+}

--- a/Source/Base/ModBaseHumanResources.cs
+++ b/Source/Base/ModBaseHumanResources.cs
@@ -25,9 +25,18 @@ namespace HumanResources
             EnableJoyGiver,
             ResearchSpeedTiedToDifficulty,
             StudySpeedTiedToDifficulty,
+            OptimizationExperimentalGrowingCache,
+            OptimizationExperimentalWeaponCache,
             FullStartupReport,
             IndividualTechsReport;
         public static FieldInfo ScenPartThingDefInfo = AccessTools.Field(typeof(ScenPart_ThingCount), "thingDef");
+
+        private static readonly SpecialRegistryCache _specialRegistry = new SpecialRegistryCache();
+        /**
+         * Registry with caches useful for the mod
+         */
+        public static IImmutableSpecialRegistryCache SpecialRegistry => _specialRegistry; 
+        
         public static List<ThingDef> 
             SimpleWeapons = new List<ThingDef>(),
             UniversalCrops = new List<ThingDef>(),
@@ -82,10 +91,13 @@ namespace HumanResources
             }
             InspectPaneUtility.Reset();
 
-            //3. Preparing knowledge support infrastructure
+            //3. Caching things required by the mod
+            _specialRegistry.NotifyAllDefsLoaded();
+            
+            //4. Preparing knowledge support infrastructure
 
             //a. Things everyone knows
-            UniversalWeapons.AddRange(DefDatabase<ThingDef>.AllDefs.Where(x => x.IsWeapon));
+            UniversalWeapons.AddRange(SpecialRegistry.AllWeapons); // Copy for later classification
             UniversalCrops.AddRange(DefDatabase<ThingDef>.AllDefs.Where(x => x.plant != null && x.plant.Sowable));
 
             //b. Minus things unlocked on research
@@ -141,7 +153,7 @@ namespace HumanResources
             }
             else Log.Message($"[HumanResources] This is what we know: {codifiedTech.EnumerableCount()} technologies processed, {UniversalCrops.Count()} basic crops, {UniversalWeapons.Count()} basic weapons + {SimpleWeapons.Count()} that require training.");
 
-            //4. Filling gaps on the database
+            //5. Filling gaps on the database
 
             //a. TechBook dirty trick, but only now this is possible!
             TechDefOf.TechBook.stuffCategories = TechDefOf.UnfinishedTechBook.stuffCategories = TechDefOf.LowTechCategories.stuffCategories;
@@ -245,6 +257,8 @@ namespace HumanResources
             EnableJoyGiver = Settings.GetHandle<bool>("EnableJoyGiver", "EnableJoyGiverTitle".Translate(), "EnableJoyGiverDesc".Translate(), true);
             ResearchSpeedTiedToDifficulty = Settings.GetHandle<bool>("ResearchSpeedTiedToDifficulty", "ResearchSpeedTiedToDifficultyTitle".Translate(), "ResearchSpeedTiedToDifficultyDesc".Translate(), true);
             StudySpeedTiedToDifficulty = Settings.GetHandle<bool>("StudySpeedTiedToDifficulty", "StudySpeedTiedToDifficultyTitle".Translate(), "StudySpeedTiedToDifficultyDesc".Translate(), true);
+            OptimizationExperimentalGrowingCache = Settings.GetHandle<bool>("OptimizationExperimentalGrowingCache", "OptimizationExperimentalGrowingCacheTitle".Translate(), "OptimizationExperimentalGrowingCacheDesc".Translate(), true);
+            OptimizationExperimentalWeaponCache = Settings.GetHandle<bool>("OptimizationExperimentalWeaponCache", "OptimizationExperimentalWeaponCacheTitle".Translate(), "OptimizationExperimentalWeaponCacheDesc".Translate(), true);
             FullStartupReport = Settings.GetHandle<bool>("FullStartupReport", "DEV: Print full startup report", null, false);
             FullStartupReport.NeverVisible = !Prefs.DevMode;
         }

--- a/Source/Base/SpecialRegistryCache.cs
+++ b/Source/Base/SpecialRegistryCache.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Linq;
+using Verse;
+
+namespace HumanResources
+{
+    public class SpecialRegistryCache : IImmutableSpecialRegistryCache
+    {
+        
+        private readonly List<ThingDef> _allWeapons = new List<ThingDef>();
+
+        
+        public IEnumerable<ThingDef> AllWeapons
+        {
+            get
+            {
+                if (ModBaseHumanResources.OptimizationExperimentalWeaponCache)
+                    return _allWeapons;
+                return DefDatabase<ThingDef>.AllDefs.Where(x => x.IsWeapon);
+            }
+        }
+
+        public void NotifyAllDefsLoaded()
+        {
+            //TODO: This is quite ugly. Those setting switches should be event-driver and actually implement strategy pattern.
+            if (ModBaseHumanResources.OptimizationExperimentalWeaponCache)
+            {
+                _allWeapons.Clear();
+                _allWeapons.AddRange(DefDatabase<ThingDef>.AllDefs.Where(x => x.IsWeapon));
+            }
+        }
+        
+    }
+}

--- a/Source/Base/UnlockManager.cs
+++ b/Source/Base/UnlockManager.cs
@@ -97,9 +97,16 @@ namespace HumanResources
             }
         }
 
+
+        public delegate void UnlockedWeaponsChangedHandler(UnlockManager sender,
+            IReadOnlyCollection<ThingDef> unlockedList);
+
+        public event UnlockedWeaponsChangedHandler OnUnlockedWeaponsChangedEvent;
+        
         public void UnlockWeapons(IEnumerable<ThingDef> newWeapons)
         {
             weapons.AddRange(newWeapons.Except(weapons).Where(x => x.IsWeapon));
+            OnUnlockedWeaponsChangedEvent?.Invoke(this, weapons);
         }
 
     }

--- a/Source/Harmony/Bill_IsFixedOrAllowedIngredient.cs
+++ b/Source/Harmony/Bill_IsFixedOrAllowedIngredient.cs
@@ -1,7 +1,6 @@
 ﻿using HarmonyLib;
 using RimWorld;
 using System;
-using System.Collections.Generic;
 using Verse;
 
 namespace HumanResources
@@ -15,7 +14,7 @@ namespace HumanResources
             Pawn trainee = WorkGiver_DoBill_TryFindBestBillIngredients.Trainee;
             if (trainee != null)
             { 
-                return !trainee.TryGetComp<CompKnowledge>().knownWeapons.Contains(thing.def);
+                return !trainee.TryGetComp<CompKnowledge>().KnownWeaponsCached.Contains(thing.def);
             }
             return true;
         }

--- a/Source/Harmony/HarmonyPatches.cs
+++ b/Source/Harmony/HarmonyPatches.cs
@@ -145,10 +145,10 @@ namespace HumanResources
         public static bool CheckKnownWeapons(Pawn pawn, ThingDef def)
         {
 
-            var knownWeapons = pawn.TryGetComp<CompKnowledge>()?.knownWeapons;
-            bool result = false;
-            if (!knownWeapons.EnumerableNullOrEmpty()) result = knownWeapons.Contains(def);
-            return result;
+            var knownWeapons = pawn.TryGetComp<CompKnowledge>()?.KnownWeaponsCached;
+            if (knownWeapons == null)
+                return false;
+            return knownWeapons.Contains(def);
         }
 
         public static void InitNewGame_Prefix()

--- a/Source/Harmony/WorkGiver_DoBill_TryFindBestBillIngredients.cs
+++ b/Source/Harmony/WorkGiver_DoBill_TryFindBestBillIngredients.cs
@@ -12,7 +12,11 @@ namespace HumanResources
 
         public static void Prefix(Bill bill, Pawn pawn)
         {
-            if ((bill.recipe == TechDefOf.TrainWeaponMelee || bill.recipe == TechDefOf.TrainWeaponShooting || bill.recipe == TechDefOf.ExperimentWeaponShooting || bill.recipe == TechDefOf.ExperimentWeaponMelee) && pawn.TryGetComp<CompKnowledge>()?.knownWeapons != null)
+            if ((bill.recipe == TechDefOf.TrainWeaponMelee
+                 || bill.recipe == TechDefOf.TrainWeaponShooting
+                 || bill.recipe == TechDefOf.ExperimentWeaponShooting
+                 || bill.recipe == TechDefOf.ExperimentWeaponMelee)
+                && pawn.TryGetComp<CompKnowledge>()?.KnownWeaponsCached != null)
             {
                 Trainee = pawn;
             }

--- a/Source/Harmony/WorkGiver_GrowerSow_JobOnCell.cs
+++ b/Source/Harmony/WorkGiver_GrowerSow_JobOnCell.cs
@@ -20,10 +20,15 @@ namespace HumanResources
                 if (!requisites.NullOrEmpty())
                 {
                     var knownPlants = pawn.TryGetComp<CompKnowledge>().knownPlants;
-                    if (Prefs.LogVerbose) Log.Warning("[HumanResources] "+pawn + "'s plant knowledge: " + knownPlants);
-                    bool flag = false;
-                    if (!knownPlants.EnumerableNullOrEmpty()) flag = knownPlants.Contains(___wantedPlantDef);
-                    if (!flag)
+                    if (knownPlants == null)
+                    {
+                        Log.Error($"[HumanResources] {pawn} plant knowledge is null. Can't plant. This is critical.");
+                        __result = null;
+                        return;
+                    }
+                    if (Prefs.LogVerbose) 
+                        Log.Message("[HumanResources] "+pawn + "'s plant knowledge: " + Diagnostic.ExpandEnumerableSafelyToString(knownPlants));
+                    if (!knownPlants.Contains(___wantedPlantDef))
                     {
                         var missing = requisites.Where(x => !x.IsKnownBy(pawn));
                         string preReqText = (missing.Count() > 1) ? missing.Select(x => x.label).ToStringSafeEnumerable() : missing.FirstOrDefault().label;

--- a/Source/HumanResources.csproj
+++ b/Source/HumanResources.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -333,6 +333,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Base\IImmutableSpecialRegistryCache.cs" />
+    <Compile Include="Base\SpecialRegistryCache.cs" />
     <Compile Include="Base\TechDatabase.cs" />
     <Compile Include="Base\TechTracker.cs" />
     <Compile Include="Books+Buildings\Building_NetworkServer.cs" />
@@ -396,6 +398,7 @@
     <Compile Include="Harmony\Pawn_JobTracker_TryTakeOrderedJob.cs" />
     <Compile Include="Harmony\WorkGiver_ConstructFinishFrames_JobOnThing.cs" />
     <Compile Include="Books+Buildings\ITab_Inventory.cs" />
+    <Compile Include="Tools\Diagnostic.cs" />
     <Compile Include="Tools\PatchOperationFindModById.cs" />
     <Compile Include="Work\JobDriver_ScanBook.cs" />
     <Compile Include="Work\JobDriver_DocumentTechDigital.cs" />

--- a/Source/Knowledge/CompKnowledge.cs
+++ b/Source/Knowledge/CompKnowledge.cs
@@ -34,6 +34,9 @@ namespace HumanResources
         private List<ThingDef> _craftableWeapons = new List<ThingDef>();
         private List<ResearchProjectDef> _knownTechs;
 
+        private List<ThingDef> m_localCacheAllKnownPlants;
+        private HashSet<ThingDef> m_localCacheMissingWeapons;
+        
         public IEnumerable<ThingDef> craftableWeapons
         {
             get
@@ -47,11 +50,20 @@ namespace HumanResources
             }
         }
 
-        public List<ThingDef> knownPlants
+        public IReadOnlyCollection<ThingDef> MissingWeapons
+        {
+            get { return m_localCacheMissingWeapons; }
+        }
+        
+        public IEnumerable<ThingDef> knownPlants
         {
             get
             {
-                return proficientPlants.Concat(UniversalCrops).ToList();
+                if (OptimizationExperimentalGrowingCache)
+                {
+                    return m_localCacheAllKnownPlants;
+                }
+                return proficientPlants.Concat(UniversalCrops);
             }
         }
 
@@ -64,7 +76,16 @@ namespace HumanResources
             }
         }
 
-        public List<ThingDef> knownWeapons => proficientWeapons.Concat(UniversalWeapons).Concat(techLevelWeapons).ToList();
+        private readonly HashSet<ThingDef> m_knownWeaponsCached = new HashSet<ThingDef>();
+        public HashSet<ThingDef> KnownWeaponsCached
+        {
+            get
+            {
+                if (ModBaseHumanResources.OptimizationExperimentalWeaponCache)
+                    return m_knownWeaponsCached;
+                return GetKnownWeaponsHot().ToHashSet();
+            }
+        }
 
         public IEnumerable<ThingDef> techLevelWeapons => SimpleWeapons.Where(x => x.techLevel <= startingTechLevel);
 
@@ -162,7 +183,7 @@ namespace HumanResources
                 if (pawn.equipment.HasAnything())
                 {
                     ThingWithComps weapon = pawn.equipment.Primary;
-                    if (!knownWeapons.Contains(weapon.def))
+                    if (!GetKnownWeaponsHot().Contains(weapon.def))
                     {
                         proficientWeapons.Add(weapon.def);
                         if (Prefs.LogVerbose) stringBuilder.Append($"{pawn.gender.GetPronoun().CapitalizeFirst()} is using a {weapon.def.label}.");
@@ -339,8 +360,46 @@ namespace HumanResources
         public void LearnCrops(ResearchProjectDef tech)
         {
             proficientPlants.AddRange(tech.UnlockedPlants());
+            UpdatePlantCache();
         }
 
+        private void UpdatePlantCache()
+        {
+            if(ModBaseHumanResources.OptimizationExperimentalGrowingCache)
+                m_localCacheAllKnownPlants = proficientPlants == null 
+                    ? UniversalCrops.ToList() 
+                    : proficientPlants.Concat(UniversalCrops).ToList();
+        }
+
+        /**
+         * This method returns known weapons with full reevaluation. May be only used during precaching
+         */
+        private IEnumerable<ThingDef> GetKnownWeaponsHot()
+        {
+            return proficientWeapons.Concat(UniversalWeapons).Concat(techLevelWeapons);
+        }
+        
+        private void UpdateWeaponCache()
+        {
+            if (!ModBaseHumanResources.OptimizationExperimentalWeaponCache)
+                return;
+            //Repopulate known weapons cache
+            m_knownWeaponsCached.Clear();
+            m_knownWeaponsCached.AddRange(GetKnownWeaponsHot());
+            /*
+             * This part is really finicky and actually breaks performance:
+             * 1. Collect unlocked weapons data universe-wide.
+             * 2. If pawn is special and has knowledge beyond colony aka ABLE TO CRAFT they can learn as exception
+             */
+            IEnumerable<ThingDef> allowed = unlocked.weapons.Concat(craftableWeapons);
+            m_localCacheMissingWeapons = SpecialRegistry.AllWeapons
+                .Except(m_knownWeaponsCached)
+                .Intersect(allowed)
+                .ToHashSet();
+            if (Prefs.LogVerbose)
+                Log.Message($"{pawn} now wants to learn those weapons: {Diagnostic.ExpandEnumerableSafelyToString(m_localCacheMissingWeapons)}");
+        }
+        
         public bool LearnTech(ResearchProjectDef tech)
         {
             if (expertise != null)
@@ -351,6 +410,7 @@ namespace HumanResources
                 _craftableWeapons.AddRange(tech.UnlockedWeapons());
                 techLevel = (TechLevel)Mathf.Max((int)tech.techLevel, (int)techLevel);
                 LearnCrops(tech);
+                UpdateWeaponCache();
                 Messages.Message("MessageStudyComplete".Translate(pawn, tech.LabelCap), pawn, MessageTypeDefOf.TaskCompletion, true);
                 return true;
             }
@@ -365,11 +425,13 @@ namespace HumanResources
         {
             if (!fearedWeapons.NullOrEmpty() && fearedWeapons.Contains(weapon)) fearedWeapons.Remove(weapon);
             proficientWeapons.Add(weapon);
+            UpdateWeaponCache();
         }
 
         public void LearnWeapons(ResearchProjectDef tech)
         {
             proficientWeapons.AddRange(tech.UnlockedWeapons());
+            UpdateWeaponCache();
         }
 
         public override void PostExposeData()
@@ -377,10 +439,9 @@ namespace HumanResources
             base.PostExposeData();
             if (Scribe.mode == LoadSaveMode.Saving && expertise != null)
             {
-                var e = expertise.Where(x => x.Value > 1f).GetEnumerator();
-                while (e.MoveNext())
+                foreach (var expertiseItem in expertise.Where(x => x.Value > 1f))
                 {
-                    expertise[e.Current.Key] = 1f;
+                    expertise[expertiseItem.Key] = 1f;
                 }
             }
             Scribe_Collections.Look(ref expertise, "Expertise");
@@ -390,13 +451,43 @@ namespace HumanResources
             Scribe_Collections.Look(ref fearedWeapons, "fearedWeapons");
             Scribe_Values.Look<TechLevel>(ref techLevel, "techLevel", 0);
             Scribe_Values.Look<TechLevel>(ref startingTechLevel, "startingTechLevel", techLevel);
-            if (Scribe.mode == LoadSaveMode.PostLoadInit && homework == null) homework = new List<ResearchProjectDef>();
+            if (Scribe.mode == LoadSaveMode.PostLoadInit)
+            {
+                if(homework == null) // Repair homework queue if not available in save
+                    homework = new List<ResearchProjectDef>();
+                // Prime caches // TODO: Wrong place? UpdateWeaponCache had to be moved to PostSpawnSetup
+                if (OptimizationExperimentalGrowingCache)
+                    UpdatePlantCache();
+            }
         }
 
         public override void PostSpawnSetup(bool respawningAfterLoad)
         {
             if (expertise == null) AcquireExpertise();
             if (techLevel == 0) techLevel = expertise.Keys.Aggregate((a, b) => a.techLevel > b.techLevel ? a : b).techLevel;
+            // Prime caches
+            if (ModBaseHumanResources.OptimizationExperimentalWeaponCache)
+            {
+                unlocked.OnUnlockedWeaponsChangedEvent += OnUnlockedWeaponsChanged;
+                UpdateWeaponCache();
+            }
+        }
+
+        public override void PostDeSpawn(Map map)
+        {
+            base.PostDeSpawn(map);
+            // No longer is directly-controlled form. Therefore doesn't need cache updates.
+            if (ModBaseHumanResources.OptimizationExperimentalWeaponCache)
+            {
+                unlocked.OnUnlockedWeaponsChangedEvent -= OnUnlockedWeaponsChanged;
+            }
+        }
+
+        private void OnUnlockedWeaponsChanged(UnlockManager sender, IReadOnlyCollection<ThingDef> unlockedlist)
+        {
+            if(Prefs.LogVerbose)
+                Log.Message($"Unlocked weapons list cache has been invalidated for {pawn} by {typeof(UnlockManager).Name}.");
+            UpdateWeaponCache();
         }
 
         private static int FactionExpertiseRange(TechLevel level)

--- a/Source/Knowledge/ITab_PawnKnowledge.cs
+++ b/Source/Knowledge/ITab_PawnKnowledge.cs
@@ -267,7 +267,7 @@ namespace HumanResources
             if (fullWeapons) Text.Font = GameFont.Small;
             else Text.Anchor = TextAnchor.UpperLeft;
             Rect scrollrect = new Rect(rightColumn.x, titleRect.yMax + margin, rightColumn.width - margin, rightColumn.height - titleRect.height - rowHeight - margin - padding * 2 - 2f);
-            var knownWeapons = PawnToShowInfoAbout.TryGetComp<CompKnowledge>()?.knownWeapons.Where(weaponsFilter);
+            var knownWeapons = PawnToShowInfoAbout.TryGetComp<CompKnowledge>()?.KnownWeaponsCached.Where(weaponsFilter);
             if (!knownWeapons.EnumerableNullOrEmpty())
             {
                 var weaponsList = knownWeapons.OrderBy(x => x.techLevel).ThenBy(x => x.IsMeleeWeapon).ThenBy(x => x.label).ToList();

--- a/Source/Tools/Diagnostic.cs
+++ b/Source/Tools/Diagnostic.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace HumanResources
+{
+    public static class Diagnostic
+    {
+        /**
+         * Prints enumerable list.
+         * Uses ToString() coercion. Less paranoid than Verse.Gen.ToStringSafeEnumerable(...)
+         */
+        public static string ExpandEnumerableSafelyToString(IEnumerable<object> sink)
+        {
+            if (sink == null)
+                return "NULL";
+            StringBuilder b = new StringBuilder();
+            foreach (var item in sink)
+            {
+                if (b.Length > 0)
+                    b.Append(", ");
+                b.Append(item);
+            }
+            return $"[{b}]";
+        }
+    }
+}

--- a/Source/Work/WorkGiver_ExperimentWeapon.cs
+++ b/Source/Work/WorkGiver_ExperimentWeapon.cs
@@ -12,7 +12,7 @@ namespace HumanResources
     {
         public override bool ShouldSkip(Pawn pawn, bool forced = false)
         {
-            IEnumerable<ThingDef> knownWeapons = pawn.TryGetComp<CompKnowledge>()?.knownWeapons;
+            IEnumerable<ThingDef> knownWeapons = pawn.TryGetComp<CompKnowledge>()?.KnownWeaponsCached;
             if (knownWeapons != null)
             {
                 IEnumerable<ThingDef> available = unlocked.weapons;
@@ -25,7 +25,7 @@ namespace HumanResources
         protected override IEnumerable<ThingDef> StudyWeapons(Bill bill, Pawn pawn)
         {
             CompKnowledge techComp = pawn.TryGetComp<CompKnowledge>();
-            IEnumerable<ThingDef> known = techComp.knownWeapons;
+            IEnumerable<ThingDef> known = techComp.KnownWeaponsCached;
             IEnumerable<ThingDef> craftable = techComp.craftableWeapons;
             IEnumerable<ThingDef> available = unlocked.weapons.Concat(craftable);
             IEnumerable<ThingDef> chosen = bill.ingredientFilter.AllowedThingDefs;

--- a/Source/Work/WorkGiver_PracticeWeapon.cs
+++ b/Source/Work/WorkGiver_PracticeWeapon.cs
@@ -10,13 +10,13 @@ namespace HumanResources
     {
         public override bool ShouldSkip(Pawn pawn, bool forced = false)
         {
-            IEnumerable<ThingDef> knownWeapons = pawn.TryGetComp<CompKnowledge>()?.knownWeapons;
+            IEnumerable<ThingDef> knownWeapons = pawn.TryGetComp<CompKnowledge>()?.KnownWeaponsCached;
             return knownWeapons == null || !knownWeapons.Any();
         }
 
         protected override IEnumerable<ThingDef> StudyWeapons(Bill bill, Pawn pawn)
         {
-            IEnumerable<ThingDef> knownWeapons = pawn.TryGetComp<CompKnowledge>().knownWeapons;
+            IEnumerable<ThingDef> knownWeapons = pawn.TryGetComp<CompKnowledge>().KnownWeaponsCached;
             IEnumerable<ThingDef> chosen = bill.ingredientFilter.AllowedThingDefs;
             return chosen.Intersect(knownWeapons);
         }


### PR DESCRIPTION
### WARNING: DO NOT MERGE - PROOF OF CONCEPT STAGE

This shows possibility of implementing active caching which may be used in JobGivers to optimize lookups.
It is not perfect as it is quite destructive to the code in its current form: from start SRP is not in greatest shape, but after my changes it looks like pigsty, which _may result in those changes actually breaking stuff_, but this topic is addressed in the end of the description.

Related to: https://github.com/jptrrs/HumanResources/issues/67

Comparisons:

Original steam master:
![og](https://user-images.githubusercontent.com/6721826/118885932-067ea100-b901-11eb-857f-489e8d92e1ab.PNG)

With changes, but cache is disabled:
![changed_no_cache](https://user-images.githubusercontent.com/6721826/118885974-10080900-b901-11eb-8b9e-0be0694a98bc.PNG)
_Oh no..._

With changes, but cache is active:
![changed_active_cache](https://user-images.githubusercontent.com/6721826/118886025-1ac29e00-b901-11eb-9e89-114c6d9fad47.PNG)

Disclaimer: Those measurements were made in heavily modded game manually with the same capture scenario and under the cases of similar call per sampling range from the Dubs profiler. Therefore those are not perfect, but I hope indicative enough.

This little endeavor showed me the following:
 - The slowest part is actually a bill scanner. This mod actually destroys selector shortcut for training furniture to ensure pawns can use their knowledge to pick from the SET of weapons offered by the furniture instead of leaving scanner ASAP like vanilla. To address that would require to extract scanner logic and cache it in the furniture comp. This is not implemented, but could be possibly done.
 - Cache does improve performance in 300 mods scenario, but this POC only fiddles with LearnWeapon and bill scanner postfix.

About code quality with optimizations:

I propose a refactor, especially for the base mod class, unlocks database and knowledge comp. I really would like to turn those classes into rimworld interface; and core logic about unlocks and selections extracted into separate agnostic classes.
Should I? If not, I hope at least those changes would be useful for independent consideration.